### PR TITLE
fix: esbuild config update to fix a CommonJS dep

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,24 +1,26 @@
-import { build } from 'esbuild';
+import { build } from "esbuild";
 
 async function runBuild() {
   try {
     await build({
-      entryPoints: ['src/index.ts'],
+      entryPoints: ["src/index.ts"],
+      format: "cjs", // Add this line
       bundle: true,
-      platform: 'node',
-      target: 'node22',
-      outdir: 'dist',
+      platform: "node",
+      target: "node22",
+      outdir: "dist",
+      outExtension: { ".js": ".cjs" },
       sourcemap: true,
       minify: true,
       banner: {
-        js: '#!/usr/bin/env node',
+        js: "#!/usr/bin/env node",
       },
       // We're bundling everything for a standalone executable
       external: [],
     });
-    console.log('Build completed successfully!');
+    console.log("Build completed successfully!");
   } catch (error) {
-    console.error('Build failed:', error);
+    console.error("Build failed:", error);
     process.exit(1);
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.5",
   "description": "Powertools for AWS Lambda MCP Server",
   "bin": {
-    "powertools-mcp": "dist/index.js"
+    "powertools-mcp": "dist/index.cjs"
   },
   "files": [
     "dist/"
@@ -26,7 +26,7 @@
     "test:unit:coverage": "vitest --run tests/unit --coverage.enabled --coverage.thresholds.100 --coverage.include='src/**'",
     "prebuild": "rimraf dist/*",
     "build": "node esbuild.config.mjs",
-    "postbuild": "chmod +x dist/index.js",
+    "postbuild": "chmod +x dist/index.cjs",
     "lint": "biome lint .",
     "lint:fix": "biome check --write .",
     "dev": "npx @modelcontextprotocol/inspector node --experimental-transform-types src/index.ts"


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

Minor build change to fix this error:

```bash
ReferenceError: require is not defined in ES module scope, you can use import instead
This file is being treated as an ES module because it has a '.js' file extension and '/Users/matt/dev/github/powertools-mcp/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
    at file:///Users/matt/dev/github/powertools-mcp/dist/index.js:95:1133
    at ModuleJob.run (node:internal/modules/esm/module_job:263:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:540:24)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)

Node.js v20.19.2
```

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**related to: https://github.com/aws-powertools/powertools-mcp/issues/61** 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-mcp/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-mcp/blob/main/.github/semantic.yml
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

I have validated this worked and fixed the issue.
```bash
$ node dist/index.cjs
{"timestamp":"2025-06-08T06:49:45.734Z","message":"starting Powertools MCP Server"}
{"timestamp":"2025-06-08T06:49:45.736Z","message":"Powertools Documentation MCP Server running on stdio"}
```
---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
