### PR TITLE
fix: handle .NET & Java url schemes

### DIFF
--- a/src/tools/fetchDocPage/README.md
+++ b/src/tools/fetchDocPage/README.md
@@ -112,7 +112,7 @@ Cache keys are generated from the URL structure to ensure uniqueness:
 ```typescript
 // Example transformation
 URL: https://docs.powertools.aws.dev/lambda/python/2.1.0/core/logger/index.md
-Key: python/2.1.0/core/logger/index.md
+Key: lambda/python/2.1.0/core/logger/index.md
 ```
 
 ### 4. Cache Validation Flow

--- a/src/tools/fetchDocPage/schemas.ts
+++ b/src/tools/fetchDocPage/schemas.ts
@@ -5,6 +5,9 @@ import { ALLOWED_DOMAIN, runtimes } from '../../constants.ts';
  * Schema for the input of the tool.
  *
  * Used to parse the tool arguments and validate them before calling the tool.
+ *
+ * TypeScript and Python runtimes support semantic versioning (x.y.z) or 'latest' in the URL,
+ * so we validate the URL structure accordingly.
  */
 const schema = {
   url: z
@@ -20,11 +23,13 @@ const schema = {
       if (!runtimes.includes(runtime as (typeof runtimes)[number])) {
         return false;
       }
-      const version = pathParts[2];
-      const isValidSemver = /^\d+\.\d+\.\d+$/.test(version);
-      const isLatest = version === 'latest';
-      if (isValidSemver === false && isLatest === false) {
-        return false;
+      if (runtime === 'typescript' || runtime === 'python') {
+        const version = pathParts[2];
+        const isValidSemver = /^\d+\.\d+\.\d+$/.test(version);
+        const isLatest = version === 'latest';
+        if (isValidSemver === false && isLatest === false) {
+          return false;
+        }
       }
 
       return true;

--- a/src/tools/fetchDocPage/tool.ts
+++ b/src/tools/fetchDocPage/tool.ts
@@ -9,7 +9,7 @@ import { buildResponse } from '../shared/buildResponse.ts';
 import { name as toolName } from './constants.ts';
 import { CacheError } from './errors.ts';
 import type { schema } from './schemas.ts';
-import { generateCacheKey, getRemotePage, getRemotePageETag } from './utils.ts';
+import { getRemotePage, getRemotePageETag } from './utils.ts';
 
 /**
  * Fetch a documentation page from remote or local cache.
@@ -37,7 +37,7 @@ const tool = async (props: {
   logger.appendKeys({ url: url.toString() });
 
   const cachePath = join(CACHE_BASE_PATH, 'markdown-cache');
-  const cacheKey = generateCacheKey({ url });
+  const cacheKey = url.pathname;
   logger.debug('Generated cache key', { cacheKey });
 
   try {

--- a/src/tools/fetchDocPage/utils.ts
+++ b/src/tools/fetchDocPage/utils.ts
@@ -76,19 +76,4 @@ const getRemotePageETag = async (url: URL): Promise<string | null> => {
   }
 };
 
-/**
- * Generate a cache key based on the URL of a documentation page.
- *
- * @param props - options for generating a cache key
- * @param props.url - the URL of the documentation page
- */
-const generateCacheKey = (props: { url: URL }): string => {
-  const { url } = props;
-  const pathParts = url.pathname.split('/').filter(Boolean);
-  const [_, runtime, version, ...rest] = pathParts;
-  const pagePath = rest.join('/');
-
-  return `${runtime}/${version}/${pagePath}`;
-};
-
-export { getRemotePage, getRemotePageETag, generateCacheKey };
+export { getRemotePage, getRemotePageETag };

--- a/tests/unit/fetchDocPage.test.ts
+++ b/tests/unit/fetchDocPage.test.ts
@@ -12,7 +12,6 @@ import {
 import { POWERTOOLS_BASE_URL } from '../../src/constants.ts';
 import { schema, tool } from '../../src/tools/fetchDocPage/index.ts';
 import {
-  generateCacheKey,
   getRemotePage,
   getRemotePageETag,
 } from '../../src/tools/fetchDocPage/utils.ts';
@@ -37,6 +36,10 @@ describe('schema', () => {
     {
       type: 'semver',
       url: `${POWERTOOLS_BASE_URL}/typescript/1.2.4/features/metrics/`,
+    },
+    {
+      type: 'dotnet no version',
+      url: `${POWERTOOLS_BASE_URL}/dotnet/features/metrics/`,
     },
   ])('parses a valid URL ($type)', ({ url }) => {
     // Act
@@ -282,21 +285,6 @@ describe('utils', () => {
       );
     });
   });
-
-  describe('generateCacheKey', () => {
-    it('generates a cache key based on the URL', () => {
-      // Prepare
-      const url = new URL(
-        `${POWERTOOLS_BASE_URL}/typescript/latest/features/metrics/index.md`
-      );
-
-      // Act
-      const cacheKey = generateCacheKey({ url });
-
-      // Assess
-      expect(cacheKey).toBe('typescript/latest/features/metrics/index.md');
-    });
-  });
 });
 
 describe('tool', () => {
@@ -358,7 +346,7 @@ describe('tool', () => {
       data: Buffer.from(expectedContent),
     });
     const url = new URL(`${baseUrl}metrics/index.md`);
-    const cacheKey = generateCacheKey({ url });
+    const cacheKey = url.pathname;
 
     // Act
     const result = await tool({ url });
@@ -387,7 +375,7 @@ describe('tool', () => {
     // Prepare
     mocks.getFromCache.mockRejectedValueOnce(new Error('Cache miss'));
     const url = new URL(`${baseUrl}no-etag-for-some-reason.md`);
-    const cacheKey = generateCacheKey({ url });
+    const cacheKey = url.pathname;
 
     // Act
     const result = await tool({ url });
@@ -413,7 +401,7 @@ describe('tool', () => {
       data: Buffer.from('54321'),
     });
     const url = new URL(`${baseUrl}metrics/index.md`);
-    const cacheKey = generateCacheKey({ url });
+    const cacheKey = url.pathname;
     const expectedContent =
       'Metrics is a feature of PowerTools for TypeScript.';
 
@@ -453,7 +441,7 @@ describe('tool', () => {
     });
     mocks.getFromCache.mockRejectedValueOnce(new Error('Cache miss'));
     const url = new URL(`${baseUrl}metrics/index.md`);
-    const cacheKey = generateCacheKey({ url });
+    const cacheKey = url.pathname;
     const expectedContent =
       'Metrics is a feature of PowerTools for TypeScript.';
 


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR tweaks the validation logic for the `url` argument of the `fetch_doc_page` tool by accounting for .NET and Java documentation URLs not having a version in them.

We are evaluating making changes to our docs scheme to streamline this, but we'll need more time to carefully consider the implications - thus the fix.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** fixes #81

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-mcp/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-mcp/blob/main/.github/semantic.yml
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
