### PR TITLE
fix: add Nodejs shebang to module entry point

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { logger } from './logger.ts';
 import { createServer } from './server.ts';


### PR DESCRIPTION
## Summary

The previous`esbuild` based build process added a the `#!/usr/bin/env node` shebang to the entrypoint for the package. When we removed `esbuild` we lost this functionality, which meant Q CLI was not able to start the MCP server.

I have tested this by using `npm link` to allow me to run the local version of this package using `npx` and set up my Q CLI environment to use the standard `npx -y powertools-for-aws-mcp` command.

**Issue number:** Fixes #101. 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
